### PR TITLE
魔力发射器修复

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,6 @@ dependencies {
     implementation rfg.deobf("curse.maven:ae2-extended-life-570458:6302098")
     implementation rfg.deobf("curse.maven:ae2-fluid-crafting-rework-623955:5504001")
     implementation rfg.deobf("curse.maven:baubles-227083:2518667")
-    implementation rfg.deobf("curse.maven:baubles-227083:2518667")
     implementation rfg.deobf("curse.maven:not-enough-energistics-515565:5234732")
     implementation rfg.deobf("curse.maven:extended-crafting-268387:2777071")
     implementation rfg.deobf("curse.maven:libnine-322344:3509087")
@@ -233,6 +232,7 @@ dependencies {
     implementation rfg.deobf("curse.maven:nae2-884359:5380800")
     implementation rfg.deobf('curse.maven:ftb-library-237167:2985811')
     implementation rfg.deobf('curse.maven:ftb-utilities-237102:3157548')
+    implementation rfg.deobf("curse.maven:botania-225643:3330934")
 }
 
 apply from: 'gradle/scripts/dependencies.gradle'

--- a/src/main/java/com/circulation/random_complement/RCConfig.java
+++ b/src/main/java/com/circulation/random_complement/RCConfig.java
@@ -23,6 +23,9 @@ public class RCConfig {
     @Config.Name("TF5")
     public static final TF5 TF5 = new TF5();
 
+    @Config.Name("Botania")
+    public static final Botania Botania = new Botania();
+
     public static class ae2{
         @Config.Comment({"Disable the Build permission check for AE2's security station"})
         @Config.Name("SecurityCache")
@@ -77,5 +80,12 @@ public class RCConfig {
         @Config.Name("RedDiagramOfTheDeputy")
         @Config.RequiresMcRestart
         public boolean RedDiagramOfTheDeputy = true;
+    }
+
+    public static class Botania{
+        @Config.Comment({"If the Mana Spreader output mana is greater than the maximum value of the Mana Spreader after installing the Mana Lens, the output will be based on the maximum value of the Mana Spreader"})
+        @Config.Name("ManaSpreaderFix")
+        @Config.RequiresMcRestart
+        public boolean ManaSpreaderFix = true;
     }
 }

--- a/src/main/java/com/circulation/random_complement/mixin/botania/MixinTileSpreader.java
+++ b/src/main/java/com/circulation/random_complement/mixin/botania/MixinTileSpreader.java
@@ -1,0 +1,29 @@
+package com.circulation.random_complement.mixin.botania;
+
+import com.circulation.random_complement.RCConfig;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.util.ITickable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import vazkii.botania.api.mana.*;
+import vazkii.botania.api.wand.IWandBindable;
+import vazkii.botania.common.block.tile.TileSimpleInventory;
+import vazkii.botania.common.block.tile.mana.TileSpreader;
+import vazkii.botania.common.entity.EntityManaBurst;
+
+@Mixin(value = TileSpreader.class, remap = false)
+public abstract class MixinTileSpreader extends TileSimpleInventory implements IManaCollector, IWandBindable, IKeyLocked, IThrottledPacket, IManaSpreader, IDirectioned, ITickable {
+
+    @Shadow
+    public abstract int getMaxMana();
+
+    @Inject(method = "getBurst", at = @At(value = "INVOKE", target = "Lvazkii/botania/common/entity/EntityManaBurst;setSourceLens(Lnet/minecraft/item/ItemStack;)V"))
+    public void Fixtransfersettings(boolean fake, CallbackInfoReturnable<EntityManaBurst> cir, @Local(ordinal = 0) BurstProperties burstProperties) {
+        if (RCConfig.Botania.ManaSpreaderFix && burstProperties.maxMana > getMaxMana()) {
+            burstProperties.maxMana = getMaxMana();
+        }
+    }
+}

--- a/src/main/java/com/circulation/random_complement/mixin/rcLateMixinLoader.java
+++ b/src/main/java/com/circulation/random_complement/mixin/rcLateMixinLoader.java
@@ -36,6 +36,7 @@ public class rcLateMixinLoader implements ILateMixinLoader {
             addModdedMixinCFG("mixins.random_complement.ftbu.json","ftbutilities");
         }
         addModdedMixinCFG("mixins.random_complement.tf5.json","thermalfoundation");
+        addModdedMixinCFG("mixins.random_complement.botania.json","botania");
     }
 
     @Override

--- a/src/main/resources/mixins.random_complement.botania.json
+++ b/src/main/resources/mixins.random_complement.botania.json
@@ -1,0 +1,17 @@
+{
+  "package": "com.circulation.random_complement.mixin.botania",
+  "required": true,
+  "refmap": "mixins.random_complement.refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "maxShiftBy": 2
+  },
+  "mixins": [
+    "MixinTileSpreader"
+  ],
+  "server": [],
+  "client": [
+	]
+}


### PR DESCRIPTION
移除重复依赖项 baubles
修复 如果魔力发射器安装了透镜，造成一次输出魔力如果发出超出上限，则无法输出的问题 ，修复后则是如果输出魔力超出上限，则按照魔力发射器内的最大魔力进行发射