### PR TITLE
Wireless terminal wipes view cells/upgrades — add legacy AE2 NBT fallback for compatibility

### DIFF
--- a/src/main/java/com/circulation/random_complement/mixin/ae2/MixinWirelessTerminalGuiObject.java
+++ b/src/main/java/com/circulation/random_complement/mixin/ae2/MixinWirelessTerminalGuiObject.java
@@ -70,14 +70,26 @@ public abstract class MixinWirelessTerminalGuiObject implements RCIConfigurableO
         return false;
     }
 
-    @Redirect(method = "loadFromNBT", at = @At(value = "INVOKE", target = "Lappeng/tile/inventory/AppEngInternalInventory;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), allow = 1)
-    public void loadViewCell(AppEngInternalInventory instance, NBTTagCompound data) {
-        instance.readFromNBT(data, "viewCell");
+    @Redirect(method = "loadFromNBT", at = @At(value = "INVOKE", target = "Lappeng/tile/inventory/AppEngInternalInventory;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), require = 1, allow = 1)
+    private void loadViewCell(AppEngInternalInventory instance, NBTTagCompound data) {
+        if (data == null) return;
+
+        if (data.hasKey("viewCell")) {
+            instance.readFromNBT(data, "viewCell");
+        } else {
+            instance.readFromNBT(data);
+        }
     }
 
-    @Redirect(method = "loadFromNBT", at = @At(value = "INVOKE", target = "Lappeng/parts/automation/UpgradeInventory;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), allow = 1)
-    public void loadUpgrade(UpgradeInventory instance, NBTTagCompound data) {
-        instance.readFromNBT(data, "upgrades");
+    @Redirect(method = "loadFromNBT", at = @At(value = "INVOKE", target = "Lappeng/parts/automation/UpgradeInventory;readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), require = 1, allow = 1)
+    private void loadUpgrade(UpgradeInventory instance, NBTTagCompound data) {
+        if (data == null) return;
+
+        if (data.hasKey("upgrades")) {
+            instance.readFromNBT(data, "upgrades");
+        } else {
+            instance.readFromNBT(data);
+        }
     }
 
     @Inject(method = "loadFromNBT", at = @At("TAIL"))


### PR DESCRIPTION
RandomComplement’s robust wireless-terminal NBT handling works fine until some other mod decides to store the terminal NBT differently… and then opening a wireless terminal nukes view cells/upgrades (the lovely “load empty → save empty” wipe).

I still don’t know which mod is messing with the NBT, and I’m done playing whack-a-mole, so this PR keeps the newer logic but adds the original AE2 legacy load method as a fallback. If the robust keyed path doesn’t match whatever another mod wrote, we fall back to AE2’s old behavior instead of deleting stuff.

TL;DR: keep the improved logic, stop wireless terminals from deleting your view cells/upgrades in cursed mod combos.